### PR TITLE
Updating AreaNodeCategories

### DIFF
--- a/app/lib/static.ts
+++ b/app/lib/static.ts
@@ -7,219 +7,38 @@ export const TILE_BASE_URL =
 
 export const nodeCategories: AreaNodeCategory[] = [
   {
-    name: "World Areas",
-    includes: ["World"],
+    name: "Collectibles",
+    includes: ["Continent", "Dungeon", "Island"],
     types: [
       {
-        name: "Ankumo Mountain",
-        icon: "ankumo-mountain.webp",
-        size: "lg",
-      },
-      {
-        name: "Battlebound Plains",
-        icon: "battlebound-plains.webp",
-        size: "lg",
-      },
-      {
-        name: "Bilbrin Forest",
-        icon: "bilbrin-forest.webp",
-        size: "lg",
-      },
-      {
-        name: "Blackrose Chapel",
-        icon: "blackrose-chapel.webp",
-        size: "lg",
-      },
-      {
-        name: "Borea's Domain",
-        icon: "boreas-domain.webp",
-        size: "lg",
-      },
-      {
-        name: "Croconys Seashore",
-        icon: "croconys-seashore.webp",
-        size: "lg",
-      },
-      {
-        name: "Dyorika Plain",
-        icon: "dyorika-plain.webp",
-        size: "lg",
-      },
-      {
-        name: "Flowering Orchard",
-        icon: "flowering-orchard.webp",
-        size: "lg",
-      },
-      {
-        name: "Forest of Giants",
-        icon: "forest-of-giants.webp",
-        size: "lg",
-      },
-      {
-        name: "Lakebar",
-        icon: "lakebar.webp",
-        size: "lg",
-      },
-      {
-        name: "Leyar Terrace",
-        icon: "leyar-terrace.webp",
-        size: "lg",
-      },
-      {
-        name: "Loghill",
-        icon: "loghill.webp",
-        size: "lg",
-      },
-      {
-        name: "Luterra Castle",
-        icon: "luterra-castle.webp",
-        size: "lg",
-      },
-      {
-        name: "Medrick Monastery",
-        icon: "medrick-monastery.webp",
-        size: "lg",
-      },
-      {
-        name: "Mokoko Village",
-        icon: "mokoko-village.webp",
-        size: "lg",
-      },
-      {
-        name: "Mount Zagoras",
-        icon: "mount-zagoras.webp",
-        size: "lg",
-      },
-      {
-        name: "Ozhorn Hill",
-        icon: "ozhorn-hill.webp",
-        size: "lg",
-      },
-      {
-        name: "Prideholme",
-        icon: "prideholme.webp",
-        size: "lg",
-      },
-      {
-        name: "Rethramis Border",
-        icon: "rethramis-border.webp",
-        size: "lg",
-      },
-      {
-        name: "Saland Hill",
-        icon: "saland-hill.webp",
-        size: "lg",
-      },
-      {
-        name: "Seasweapt Woods",
-        icon: "seasweapt-woods.webp",
-        size: "lg",
-      },
-      {
-        name: "Skyreach Steppe",
-        icon: "skyreach-steppe.webp",
-        size: "lg",
-      },
-      {
-        name: "Sunbright Hill",
-        icon: "sunbright-hill.webp",
-        size: "lg",
-      },
-      {
-        name: "Sweetwater Forest",
-        icon: "sweetwater-forest.webp",
-        size: "lg",
-      },
-      {
-        name: "Wavestrand Port",
-        icon: "wavestrand-port.webp",
-        size: "lg",
+        name: "Mokoko Seed",
+        icon: "minimap_symbol_1_121.webp",
       },
     ],
   },
   {
-    name: "Areas & Orientation",
-    includes: ["Continent", "Dungeon", "Island", "World"],
+    name: "General Orientation",
+    includes: ["Continent", "Dungeon", "Island"],
     types: [
       {
         name: "Map Transition",
         icon: "minimap_symbol_7.webp",
       },
       {
-        name: "Vista",
-        icon: "viewpoint.webp",
+        name: "Secret Passage",
+        icon: "secret-door.webp",
       },
       {
-        name: "Co-op Quest Area",
-        icon: "minimap_symbol_88.webp",
+        name: "Secret Mechanics",
+        icon: "lever.webp",
       },
       {
-        name: "Sudden Quest Area",
-        icon: "minimap_symbol_81.webp",
+        name: "Music",
+        icon: "double-quaver.webp",
       },
       {
         name: "Standard Dungeon",
         icon: "minimap_symbol_3.webp",
-      },
-      {
-        name: "Ark Dungeon",
-        icon: "minimap_symbol_4.webp",
-      },
-      {
-        name: "Sailing Dungeon",
-        icon: "minimap_symbol_1_204.webp",
-      },
-      {
-        name: "Chaos Gate",
-        icon: "minimap_symbol_6.webp",
-      },
-      {
-        name: "Triport",
-        icon: "minimap_symbol_73.webp",
-      },
-      {
-        name: "Port",
-        icon: "minimap_symbol_92.webp",
-      },
-      {
-        name: "Dock",
-        icon: "minimap_symbol_1_47.webp",
-      },
-      {
-        name: "Island",
-        icon: "minimap_symbol_219.webp",
-      },
-      {
-        name: "PvP Island",
-        icon: "minimap_symbol_218.webp",
-      },
-      {
-        name: "Ghost Ship",
-        icon: "minimap_symbol_1_210.webp",
-      },
-      {
-        name: "Vast Sea",
-        icon: "minimap_symbol_1_328.webp",
-      },
-      {
-        name: "Turquoise Portal",
-        icon: "minimap_symbol_1_111.webp",
-      },
-      {
-        name: "Water Vehicle",
-        icon: "minimap_symbol_72.webp",
-      },
-      {
-        name: "Elevator",
-        icon: "minimap_symbol_1_1.webp",
-      },
-      {
-        name: "Travelator",
-        icon: "minimap_symbol_1_2.webp",
-      },
-      {
-        name: "Teleport?",
-        icon: "minimap_symbol_1_3.webp",
       },
       {
         name: "Stairs (Up)",
@@ -230,8 +49,24 @@ export const nodeCategories: AreaNodeCategory[] = [
         icon: "minimap_symbol_1_5.webp",
       },
       {
-        name: "Treasure Map Location",
-        icon: "minimap_symbol_1_0.webp",
+        name: "Elevator",
+        icon: "minimap_symbol_1_1.webp",
+      },
+      {
+        name: "Travelator",
+        icon: "minimap_symbol_1_2.webp",
+      },
+      {
+        name: "Turquoise Portal",
+        icon: "minimap_symbol_1_111.webp",
+      },
+      {
+        name: "Water Vehicle",
+        icon: "minimap_symbol_72.webp",
+      },
+      {
+        name: "Teleport?",
+        icon: "minimap_symbol_1_3.webp",
       },
       {
         name: "Lime Portal",
@@ -245,37 +80,63 @@ export const nodeCategories: AreaNodeCategory[] = [
         name: "Purple Portal",
         icon: "minimap_symbol_1_317.webp",
       },
-      {
-        name: "Secret Passage",
-        icon: "secret-door.webp",
-      },
-      {
-        name: "Secret Mechanics",
-        icon: "lever.webp",
-      },
     ],
   },
   {
-    name: "Collectibles",
-    includes: ["Continent", "Dungeon", "Island"],
+    name: "Land Orientation",
+    includes: ["Continent"],
     types: [
       {
-        name: "Mokoko Seed",
-        icon: "minimap_symbol_1_121.webp",
+        name: "Triport",
+        icon: "minimap_symbol_73.webp",
       },
-    ],
+      {
+        name: "Ark Dungeon",
+        icon: "minimap_symbol_4.webp",
+      },
+    ]
   },
   {
-    name: "Exchange",
-    includes: ["Continent", "Dungeon", "Island"],
+    name: "World Orientation",
+    includes: ["World"],
+    types: [
+      {
+        name: "Island",
+        icon: "minimap_symbol_219.webp",
+      },
+      {
+        name: "PvP Island",
+        icon: "minimap_symbol_218.webp",
+      },
+      {
+        name: "Port",
+        icon: "minimap_symbol_92.webp",
+      },
+      {
+        name: "Dock",
+        icon: "minimap_symbol_1_47.webp",
+      },
+      {
+        name: "Ghost Ship",
+        icon: "minimap_symbol_1_210.webp",
+      },
+      {
+        name: "Vast Sea",
+        icon: "minimap_symbol_1_328.webp",
+      },
+      {
+        name: "Sailing Dungeon",
+        icon: "minimap_symbol_1_204.webp",
+      },
+    ]
+  },  
+  {
+    name: "Island Exchange",
+    includes: ["Island"],
     types: [
       {
         name: "Sea Bounty Exchange",
         icon: "minimap_symbol_1_318.webp",
-      },
-      {
-        name: "Rapport Exchange",
-        icon: "minimap_symbol_1_275.webp",
       },
       {
         name: "Island Soul Exchange",
@@ -289,6 +150,16 @@ export const nodeCategories: AreaNodeCategory[] = [
         name: "Masterpiece Exchange",
         icon: "minimap_symbol_1_123.webp",
       },
+    ],
+  },
+  {
+    name: "Land Exchange",
+    includes: ["Continent"],
+    types: [
+      {
+        name: "Rapport Exchange",
+        icon: "minimap_symbol_1_275.webp",
+      }, 
       {
         name: "World Tree Leaf Exchange",
         icon: "minimap_symbol_1_320.webp",
@@ -320,8 +191,12 @@ export const nodeCategories: AreaNodeCategory[] = [
         icon: "hidden_story.webp",
       },
       {
-        name: "Music",
-        icon: "double-quaver.webp",
+        name: "Vista",
+        icon: "viewpoint.webp",
+      },
+      {
+        name: "Gold Named Enemy",
+        icon: "minimap_symbol_69.webp",
       },
     ],
   },
@@ -330,20 +205,16 @@ export const nodeCategories: AreaNodeCategory[] = [
     includes: ["Continent", "Dungeon", "Island"],
     types: [
       {
-        name: "Boss 1",
+        name: "Boss",
         icon: "minimap_symbol_1.webp",
       },
       {
-        name: "Boss 2",
+        name: "World Boss",
         icon: "minimap_symbol_40.webp",
       },
       {
         name: "Silver Named Enemy",
         icon: "minimap_symbol_76.webp",
-      },
-      {
-        name: "Gold Named Enemy",
-        icon: "minimap_symbol_69.webp",
       },
     ],
   },
@@ -495,7 +366,7 @@ export const nodeCategories: AreaNodeCategory[] = [
   },
   {
     name: "Merchants",
-    includes: ["Continent", "Dungeon", "Island"],
+    includes: ["Continent", "Island"],
     types: [
       {
         name: "Trade Skill Merchant",
@@ -550,7 +421,7 @@ export const nodeCategories: AreaNodeCategory[] = [
         icon: "minimap_symbol_1_124.webp",
       },
       {
-        name: "Unknown Merchant 3 - TBC",
+        name: "Proving Grounds Merchant",
         icon: "minimap_symbol_1_125.webp",
       },
       {
@@ -561,7 +432,7 @@ export const nodeCategories: AreaNodeCategory[] = [
   },
   {
     name: "NPCs",
-    includes: ["Continent", "Dungeon", "Island"],
+    includes: ["Continent", "Island"],
     types: [
       {
         name: "Rapport",
@@ -571,23 +442,15 @@ export const nodeCategories: AreaNodeCategory[] = [
   },
   {
     name: "Quests",
-    includes: ["Continent", "Dungeon", "Island"],
+    includes: ["Continent", "Island"],
     types: [
       {
         name: "Adventure Quest",
         icon: "minimap_symbol_247.webp",
       },
       {
-        name: "Chain Adventure Quest",
-        icon: "minimap_symbol_239.webp",
-      },
-      {
         name: "Side Quest",
         icon: "minimap_symbol_18.webp",
-      },
-      {
-        name: "Chain Side Quest",
-        icon: "minimap_symbol_253.webp",
       },
       {
         name: "Repeatable Quest",
@@ -850,11 +713,25 @@ export const nodeCategories: AreaNodeCategory[] = [
     ],
   },
   {
-    name: "Symbols",
-    includes: ["Continent", "Dungeon", "Island"],
+    name: "General Event",
+    includes: ["Continent", "Island"],
     types: [
       {
-        name: "Crimson Chaos Gate",
+        name: "Co-op Quest Area",
+        icon: "minimap_symbol_88.webp",
+      },
+    ]
+  },
+  {
+    name: "Land Event",
+    includes: ["Continent"],
+    types: [
+      {
+        name: "Chaos Gate",
+        icon: "minimap_symbol_6.webp",
+      },
+      {
+        name: "Mayhem Chaos Gate",
         icon: "minimap_symbol_64.webp",
       },
       {
@@ -868,6 +745,141 @@ export const nodeCategories: AreaNodeCategory[] = [
       {
         name: "Pink Chaos Gate",
         icon: "minimap_symbol_67.webp",
+      },
+      {
+        name: "Sudden Quest Area",
+        icon: "minimap_symbol_81.webp",
+      },
+    ],
+  },
+  {
+    name: "World Areas",
+    includes: ["World"],
+    types: [
+      {
+        name: "Ankumo Mountain",
+        icon: "ankumo-mountain.webp",
+        size: "lg",
+      },
+      {
+        name: "Battlebound Plains",
+        icon: "battlebound-plains.webp",
+        size: "lg",
+      },
+      {
+        name: "Bilbrin Forest",
+        icon: "bilbrin-forest.webp",
+        size: "lg",
+      },
+      {
+        name: "Blackrose Chapel",
+        icon: "blackrose-chapel.webp",
+        size: "lg",
+      },
+      {
+        name: "Borea's Domain",
+        icon: "boreas-domain.webp",
+        size: "lg",
+      },
+      {
+        name: "Croconys Seashore",
+        icon: "croconys-seashore.webp",
+        size: "lg",
+      },
+      {
+        name: "Dyorika Plain",
+        icon: "dyorika-plain.webp",
+        size: "lg",
+      },
+      {
+        name: "Flowering Orchard",
+        icon: "flowering-orchard.webp",
+        size: "lg",
+      },
+      {
+        name: "Forest of Giants",
+        icon: "forest-of-giants.webp",
+        size: "lg",
+      },
+      {
+        name: "Lakebar",
+        icon: "lakebar.webp",
+        size: "lg",
+      },
+      {
+        name: "Leyar Terrace",
+        icon: "leyar-terrace.webp",
+        size: "lg",
+      },
+      {
+        name: "Loghill",
+        icon: "loghill.webp",
+        size: "lg",
+      },
+      {
+        name: "Luterra Castle",
+        icon: "luterra-castle.webp",
+        size: "lg",
+      },
+      {
+        name: "Medrick Monastery",
+        icon: "medrick-monastery.webp",
+        size: "lg",
+      },
+      {
+        name: "Mokoko Village",
+        icon: "mokoko-village.webp",
+        size: "lg",
+      },
+      {
+        name: "Mount Zagoras",
+        icon: "mount-zagoras.webp",
+        size: "lg",
+      },
+      {
+        name: "Ozhorn Hill",
+        icon: "ozhorn-hill.webp",
+        size: "lg",
+      },
+      {
+        name: "Prideholme",
+        icon: "prideholme.webp",
+        size: "lg",
+      },
+      {
+        name: "Rethramis Border",
+        icon: "rethramis-border.webp",
+        size: "lg",
+      },
+      {
+        name: "Saland Hill",
+        icon: "saland-hill.webp",
+        size: "lg",
+      },
+      {
+        name: "Seaswept Woods",
+        icon: "seasweapt-woods.webp",
+        size: "lg",
+      },
+      {
+        name: "Skyreach Steppe",
+        icon: "skyreach-steppe.webp",
+        size: "lg",
+      },
+      {
+        name: "Sunbright Hill",
+        icon: "sunbright-hill.webp",
+        size: "lg",
+      },
+      {
+        name: "Sweetwater Forest",
+        icon: "sweetwater-forest.webp",
+        size: "lg",
+      },
+      {
+        name: "Wavestrand Port",
+        icon: "wavestrand-port.webp",
+        size: "lg",
       },
     ],
   },

--- a/app/lib/static.ts
+++ b/app/lib/static.ts
@@ -865,7 +865,7 @@ export const nodeCategories: AreaNodeCategory[] = [
         size: "lg",
       },
       {
-        name: "Seaswept Woods",
+        name: "Seasweapt Woods",
         icon: "seasweapt-woods.webp",
         size: "lg",
       },

--- a/app/lib/static.ts
+++ b/app/lib/static.ts
@@ -231,7 +231,7 @@ export const nodeCategories: AreaNodeCategory[] = [
         icon: "minimap_symbol_154.webp",
       },
     ]
-  }
+  },
   {
     name: "Land Services",
     includes: ["Continent"],
@@ -371,7 +371,7 @@ export const nodeCategories: AreaNodeCategory[] = [
         icon: "minimap_symbol_1_109.webp",
       },
     ]
-  }
+  },
   {
     name: "Merchants",
     includes: ["Continent", "Island"],

--- a/app/lib/static.ts
+++ b/app/lib/static.ts
@@ -219,7 +219,21 @@ export const nodeCategories: AreaNodeCategory[] = [
     ],
   },
   {
-    name: "Services",
+    name: "General Services",
+    includes: ["Continent", "Island"],
+    types: [
+      {
+        name: "Repairer",
+        icon: "minimap_symbol_158.webp",
+      },
+      {
+        name: "Wandering Merchant",
+        icon: "minimap_symbol_154.webp",
+      },
+    ]
+  }
+  {
+    name: "Land Services",
     includes: ["Continent"],
     types: [
       {
@@ -271,20 +285,8 @@ export const nodeCategories: AreaNodeCategory[] = [
         icon: "minimap_symbol_1_186.webp",
       },
       {
-        name: "Statue of Gienah (Island Souls)",
-        icon: "minimap_symbol_1_109.webp",
-      },
-      {
-        name: "Marina",
-        icon: "minimap_symbol_230.webp",
-      },
-      {
         name: "Shipbuilder",
         icon: "minimap_symbol_183.webp",
-      },
-      {
-        name: "Wandering Merchant",
-        icon: "minimap_symbol_154.webp",
       },
       {
         name: "Voyage Manager",
@@ -305,14 +307,6 @@ export const nodeCategories: AreaNodeCategory[] = [
       {
         name: "Processing",
         icon: "minimap_symbol_208.webp",
-      },
-      {
-        name: "Repairer",
-        icon: "minimap_symbol_158.webp",
-      },
-      {
-        name: "Guardian Raid Soul",
-        icon: "minimap_symbol_1_274.webp",
       },
       {
         name: "Gem Expert",
@@ -364,6 +358,20 @@ export const nodeCategories: AreaNodeCategory[] = [
       },
     ],
   },
+  {
+    name: "World Services",
+    includes: ["World"],
+    types: [
+      {
+        name: "Marina",
+        icon: "minimap_symbol_230.webp",
+      },
+      {
+        name: "Statue of Gienah (Island Souls)",
+        icon: "minimap_symbol_1_109.webp",
+      },
+    ]
+  }
   {
     name: "Merchants",
     includes: ["Continent", "Island"],


### PR DESCRIPTION
**Change Notes Summary:** 
1. Reorder categories based on usefulness to put more frequently used icons closer to the top.
2. Created new area specific categories to better filter the icons based on area.
    2a. Some category filters have been updated to reflect this change.
3. Renamed some of the icons to be more accurate / reflective.

**Change Notes Breakdown:**
All categories are listed in the new order (as indicated in change notes summary 1):
   - Collectibles (Continent, Dungeon, Island)
   - Adventure Tome (Continent, Dungeon)
     - The following icons are now a part of this category.
	    - 'Vista' moved from 'Areas & Orientation'
	    - 'Gold Named Enemy' moved from 'Enemies'
   - [Renamed] General Orientation (Continent, Dungeon, Island) 
     - Category was renamed from 'Areas & Orientation'. This category is a subset of 'Areas & Orientation'
     - The following icons are now a part of this category.
	    - 'Music' moved from 'Adventure Tome'
   - [New] Land Orientation (Continent) 
     - This category is a subset of 'Areas & Orientation'
     - The following icons are now a part of this category.
	    - 'Triport' moved from 'Areas & Orientation'
	    - 'Ark Dungeon' moved from 'Areas & Orientation'
   - [New] World Orientation (World) 
     - This category is a subset of 'Areas & Orientation'
     - The following icons are now a part of this category.
	    - 'Island' moved from 'Areas & Orientation'
	    - 'Pvp Island' moved from 'Areas & Orientation' 
	    - 'Port' moved from 'Areas & Orientation' 
	    - 'Dock' moved from 'Areas & Orientation'
	    - 'Ghost Ship' moved from 'Areas & Orientation'
	    - 'Vast Sea' moved from 'Areas & Orientation'
	    - 'Sailing Dungeon' moved from 'Areas & Orientation'
   - [New] Island Exchange (Island)
     - This category is a subset of 'Exchange'
     - The following icons are now a part of this category.
	    - 'Sea Bounty Exchange' moved from 'Exchange'
	    - 'Island Soul Exchange' moved from 'Exchange' 
	    - 'Giants Heart Exchange' moved from 'Exchange' 
	    - 'Masterpiece Exchange' moved from 'Exchange'
   - [New] Land Exchange (Continent) 
     - This category is a subset of 'Exchange'
     - The following icons are now a part of this category.
	    - 'Rapport Exchange' moved from 'Exchange'
	    - 'World Tree Leaf Exchange' moved from 'Exchange' 
	    - 'Ignea Token Exchange' moved from 'Exchange'
	    - 'Omnium Star Exchange' moved from 'Exchange' 
   - Enemies (Continent, Dungeon, Island)
     - The following icons have been renamed:
	    - 'Boss 1' has been renamed to 'Boss'
	    - 'Boss 2' has been renamed to 'World Boss'
   - [New] General Services (Continent, Island)
        - The following icons are now a part of the this category.
	    - 'Wandering Merchant' moved from 'Services'
	    - 'Repairer' moved from 'Services'
   - [Renamed] Land Services (Continent)
      - Category was renamed from 'Services'
      - Removed 'Guardian Raid Soul' icon.
   - [New] World Services
        - The following icons are now a part of the this category.
	    - 'Marina' moved from 'Services'
	    - 'Statue of Gienah (Island Souls)' moved from 'Services'
   - Merchant (Continent, Island)
     - The following icons have been renamed:
	    - 'Unknown Merchant 3 - TBC' has been renamed to 'Proving Grounds Merchant'.
   - NPCs (Continent, Island)
   - Quests (Continent, Island)
     - Removed 'Rapport Quest' icon
     - Removed all 'Chain Quest' icon variations (Rapport, Adventure, Side)
   - Sea Bounties (World)
   - [Renamed] Sea Types (World)
     - Category was renamed from 'Sea'.
   - Trade Skills (Continent, Island)
   - [New] General Event (Continent, Island) 
     - This category is a subset of 'Areas & Orientation'
     - The following icons are now a part of the 'General Event' category.
	    - 'Co-op Quest Area' moved from 'Areas & Orientation'
   - [Renamed] Land Event (Continent)
     - Category was renamed from 'Symbols'
     - The following icons have been renamed:
	    - 'Crimson Chaos Gate' has been renamed to 'Mayhem Chaos Gate'
     - The following icons are now a part of the this category.
	    - 'Chaos Gate' moved from 'Areas & Orientation'
	    - 'Sudden Quest Area' moved from 'Areas & Orientation'
   - World Areas

---

**Dev Notes @lmachens** 
I think there are a total of 4 breaking changes which need to be coordinated when merged. 
- The following icons have been renamed.
   - 'Crimson Chaos Gate' -> 'Mayhem Chaos Gate'
   - 'Boss 1' -> 'Boss'
   - 'Boss 2' -> 'World Boss'
   - Unknown Merchant 3 - TBC' -> 'Proving Grounds Merchant' 