### PR TITLE
🐛 Island names with "'s" in the name have wrong maxroll guide links

### DIFF
--- a/app/components/IslandGuideLink.tsx
+++ b/app/components/IslandGuideLink.tsx
@@ -6,7 +6,7 @@ type IslandGuideLinkProps = {
 };
 const IslandGuideLink = ({ areaNode }: IslandGuideLinkProps) => {
   const path =
-    areaNode.name?.toLowerCase().replace(/\s/g, "-").replace(/'/g, "s") || "";
+    areaNode.name?.toLowerCase().replace(/\s/g, "-").replace(/'/g, "") || "";
   return (
     <Anchor href={`https://lost-ark.maxroll.gg/island/${path}`} target="_blank">
       Maxroll Island Guide


### PR DESCRIPTION
Fixes #176